### PR TITLE
added nohup to handler for remote connection support

### DIFF
--- a/roles/tj-webapp-deploy/handlers/main.yaml
+++ b/roles/tj-webapp-deploy/handlers/main.yaml
@@ -1,3 +1,3 @@
 - name: restart webapp
-  shell: cd {{ webapp_dest_dir }}; {{ webapp_dest_dir }}/dist/example-webapp-linux </dev/null >/dev/null 2>&1 &
+  shell: cd {{ webapp_dest_dir }};nohup {{ webapp_dest_dir }}/dist/example-webapp-linux </dev/null >/dev/null 2>&1 &
   listen: "restart webapp"


### PR DESCRIPTION
process would die after the parent connection terminated after the play was run on remote playbook run.  Adding nohup to the handler solves this.  Any future work on this end to be more resilient should switch to using actual startup scripts and service/systemd.